### PR TITLE
Mrcairo/bug fixes around days without date

### DIFF
--- a/NAPIGallery/APOD/APODContentView.swift
+++ b/NAPIGallery/APOD/APODContentView.swift
@@ -17,30 +17,7 @@ struct APODContentView: View {
     var body: some View {
         HStack {
             VStack {
-                if let title = (viewModel.title) {
-                    Spacer()
-                    Text(title)
-                        .font(.title)
-                        .lineLimit(3)
-                        .multilineTextAlignment(.center)
-                }
-                // Display the date
-                Text(NAPIService.standardDateString(date.startDate))
-                    .font(.headline).fontWeight(.heavy)
-                    .padding(.top, 5)
-                    .padding(.bottom, 10)
-
-                GeometryReader { geo in
-                    if geo.size.height > geo.size.width {
-                        VStack {
-                            APODContentMixView(data: viewModel.apodData)
-                        }
-                    } else {
-                        HStack {
-                            APODContentMixView(data: viewModel.apodData)
-                        }
-                    }
-                }
+                validAPODView
             }
             .onAppear(perform: {
                 callService()
@@ -58,6 +35,37 @@ struct APODContentView: View {
                                                 Label("Select Date", systemImage: "calendar")
                                                     .labelStyle(IconOnlyLabelStyle())
         }))
+    
+
+        }
+    
+    var validAPODView: some View {
+        Group {
+            if let title = (viewModel.title) {
+                Spacer()
+                Text((title == "FAILURE") ? "Nothing Today" : title)
+                    .font(.title)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.center)
+            }
+            // Display the date
+            Text(NAPIService.standardDateString(date.startDate))
+                .font(.headline).fontWeight(.heavy)
+                .padding(.top, 5)
+                .padding(.bottom, 10)
+
+            GeometryReader { geo in
+                if geo.size.height > geo.size.width {
+                    VStack {
+                        APODContentMixView(data: viewModel.apodData)
+                    }
+                } else {
+                    HStack {
+                        APODContentMixView(data: viewModel.apodData)
+                    }
+                }
+            }
+        }
     }
     
     private func callService() {

--- a/NAPIGallery/APOD/Model/APODDataModel.swift
+++ b/NAPIGallery/APOD/Model/APODDataModel.swift
@@ -15,6 +15,9 @@ enum APODMediaType: Int, Codable {
 }
 
 struct APODDataModel: Codable {
+    static let initialServiceVersion = "000"
+    static let unknownServiceVersion = "-1"
+    static let failureTitle = "FAILURE"
     private(set) var copyright: String?
     private(set) var date: String?
     private(set) var explanation: String?
@@ -39,6 +42,10 @@ struct APODDataModel: Codable {
         return nil
     }
     
+    func isFailure() -> Bool {
+        return title == "FAILURE" && date == "1970-01-01" && url == nil
+    }
+    
     init() {
         title = ""
         explanation = ""
@@ -53,14 +60,14 @@ struct APODDataModel: Codable {
     init(asFailure: Bool) {
         self.init()
         if asFailure {
-            title = "FAILURE"
-            explanation = "Failed to fetch real APOD data"
+            title = APODDataModel.failureTitle
+            explanation = ""
             hdurl = nil
             url = nil
             copyright = ""
-            date = "1970-01-01"
+            date = ""
             media_type = ""
-            service_version = "0"
+            service_version = APODDataModel.initialServiceVersion
         }
     }
     

--- a/NAPIGallery/APOD/View/APODContentMixView.swift
+++ b/NAPIGallery/APOD/View/APODContentMixView.swift
@@ -18,19 +18,20 @@ struct APODContentMixView: View {
     var body: some View {
         ScrollView {
             VStack {
-                if (data.isImage()) {
+                if data.isImage() {
                     APODImageView(mediaType: (data.mediaURL() != nil) ? .imageURL : .imageData,
                                   mediaData: data.mediaURL()?.absoluteString.data(using: .utf8) ?? Data())
                         .scaleEffect((self.horizontalSizeClass ?? .compact) == .compact ? 1.0 : 0.75)
-                } else {
+                } else if data.isVideo() {
                     APODVideoView(mediaType: .video,
                                   mediaData: data.mediaURL()?.absoluteString.data(using: .utf8) ?? Data())
                         .scaleEffect((self.horizontalSizeClass ?? .compact) == .compact ? 1.0 : 0.75)
+                } else {
+                    Spacer(minLength: 15)
+                    Text(data.explanation ?? "Description not provided.")
+                        .font(.body)
+                        .padding()
                 }
-                Spacer(minLength: 15)
-                Text(data.explanation ?? "Description not provided.")
-                    .font(.body)
-                    .padding()
             }
         }
     }

--- a/NAPIGallery/APOD/View/APODImageView.swift
+++ b/NAPIGallery/APOD/View/APODImageView.swift
@@ -56,8 +56,6 @@ struct APODImageView: View {
                 APODImageView.failImage()
             }
         }
-
-        APODImageView.failImage()
     }
     
     init(mediaType: APODMediaType, mediaData: Data) {

--- a/NAPIGallery/Rovers/View/RoverDetailView.swift
+++ b/NAPIGallery/Rovers/View/RoverDetailView.swift
@@ -26,7 +26,7 @@ private struct RoverImageStackView: View {
                 index in
                 VStack {
                     RoverImageView(imageUrlString: dataModel[index].imageUrlString)
-                        .animation(Animation.easeIn(duration: 0.2))
+                        .animation(.none)
                     Text("Earth Date: \(dataModel[index].earthDate) (Sol: \(dataModel[index].sol))")
                     Text(" ")
                 }

--- a/NAPIGallery/System/Models/NAPIKey.swift
+++ b/NAPIGallery/System/Models/NAPIKey.swift
@@ -29,7 +29,7 @@ class NAPIKey: ObservableObject {
     private let documentsURL: URL
     
     public func isDemoKey() -> Bool {
-        return value == "DEMO_KEY"
+        return value == NAPIKey.demoKey
     }
     
     private var key: String {
@@ -44,14 +44,14 @@ class NAPIKey: ObservableObject {
 
     private func loadKey() -> String {
         guard let file = URL(string: "\(documentsURL)napi_key.txt") else {
-            return "DEMO_KEY"
+            return NAPIKey.demoKey
         }
         
         if let key = try? String(contentsOfFile: file.path, encoding: .utf8) {
             return key
         }
         
-        return "DEMO_KEY"
+        return NAPIKey.demoKey
     }
     
     private func saveKey(_ key: String) -> Bool {


### PR DESCRIPTION
* Updated APODImageView by removing poorly placed failImage().
* Added constants to APODDataModel to differentiate an initialServiceVersion and an unknownServiceVersion.
* Updated the title for days in APOD that are missing data to 'Nothing Today' instead of Failure.
* Updated APODContentMixView so that it doesn't assume that if the content is not an image that it must be a video.